### PR TITLE
The test loop in the "get question" to start from 0

### DIFF
--- a/starter-code/test/test.js
+++ b/starter-code/test/test.js
@@ -49,7 +49,7 @@ describe('SortedList', function() {
 
     it('should return the element in that position', function() {
       var foo = 10;
-      for(i=1; i<200; i++) {
+      for(let i=0; i<200; i++) {
         sl.add(foo*i);
         assert.equal(sl.get(i), foo*i);
       }


### PR DESCRIPTION
Before this change, the answer to the question

```
    4) should return the element in that position
```

is:

```
  get(i) {
    if(i > this.items.length) {
      throw new Error("OutOfBoundsd")
    }
    return this.items[i-1]
  }
```

That's because we're doing this in the test:

```
      for(i=1; i<200; i++) {
        sl.add(foo*i);
        assert.equal(sl.get(i), foo*i);
      }
```

That is we do `sl.add(foo*i);` (i.e. `sl.add(10*1);`) and then we look at `sl.get(i)` (i.e. `sl.get(1)`) and expect the value to be `10*1`.

This changes that do we're looking for the 0th item the first time we add something.